### PR TITLE
FE: fix: 한글 메시지 마지막 글자가 중복되어 보내지는 버그 수정

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -307,6 +307,10 @@ const ChatInput = forwardRef(({
   }, [message, setMessage, setShowMentionList, messageInputRef]);
 
   const handleKeyDown = useCallback((e) => {
+    if (e.nativeEvent.isComposing) {
+      return;
+    }
+    
     if (showMentionList) {
       const participants = getFilteredParticipants(room); // room 객체 전달
       const participantsCount = participants.length;


### PR DESCRIPTION
## 문제 상황
메시지의 마지막 글자가 한글이면 해당 글자만 메시지로 한 번 더 전송됨

<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/6b2a2fae-a629-4d81-ae77-ad817aafbda0" />

## 원인

## 해결