### PR TITLE
fix: 화면 스크롤 안 되어 요소가 끝까지 안 보이는 버그 수정

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -91,14 +91,16 @@ body {
 html,
 body {
   height: 100vh;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   margin: 0;
   padding: 0;
 }
 
 #__next {
   height: 100vh;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Auth Layout */


### PR DESCRIPTION
## 문제 상황

화면 스크롤이 안 돼서 작은 화면에서는 요소의 아랫쪽이 보이지 않음

<img width="500" height="400" alt="bug_화면스크롤안됨" src="https://github.com/user-attachments/assets/30ac1763-2083-420d-bc00-7a5c3ec9bfac" />

## 원인

globals.css의 html, body, #__next에 대해서 `overflow: hidden;`이 걸려 있었음

## 해결

<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/a9148fce-49d7-423c-8f0c-fae3f825859d" />
