### PR TITLE
fix: 에러 발생 시 모달창이 안 뜨도록 수정함

### DIFF
--- a/frontend/components/ErrorCounter.js
+++ b/frontend/components/ErrorCounter.js
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+
+const ErrorCounter = () => {
+  const [errorCount, setErrorCount] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [errors, setErrors] = useState([]);
+
+  useEffect(() => {
+    const handleCustomError = (event) => {
+      const errorDetail = event.detail;
+      
+      setErrorCount(prev => prev + 1);
+      setErrors(prev => [...prev, errorDetail]);
+    };
+
+    // 커스텀 에러 이벤트 리스너
+    window.addEventListener('customError', handleCustomError);
+
+    return () => {
+      window.removeEventListener('customError', handleCustomError);
+    };
+  }, []);
+
+  const clearErrors = () => {
+    setErrorCount(0);
+    setErrors([]);
+    setShowModal(false);
+  };
+
+  if (errorCount === 0) return null;
+
+  return (
+    <>
+      {/* 하단 고정 에러 카운터 버튼 */}
+      <div 
+        className="fixed bottom-4 left-4 z-50 cursor-pointer"
+        onClick={() => setShowModal(true)}
+      >
+        <div className="bg-red-500 text-white px-3 py-2 rounded-full shadow-lg hover:bg-red-600 transition-colors flex items-center gap-2">
+          <div className="w-3 h-3 bg-white rounded-full flex items-center justify-center">
+            <span className="text-red-500 text-xs font-bold">!</span>
+          </div>
+          <span className="font-medium">{errorCount} error{errorCount > 1 ? 's' : ''}</span>
+        </div>
+      </div>
+
+      {/* 에러 모달 (수동으로 열기) */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-gray-900 text-white rounded-lg shadow-xl max-w-4xl max-h-96 w-full mx-4 flex flex-col">
+            {/* 모달 헤더 */}
+            <div className="flex justify-between items-center p-4 border-b border-gray-700">
+              <div className="flex items-center gap-2">
+                <span className="text-red-400 text-xl">⚠</span>
+                <h2 className="text-xl font-bold text-red-400">
+                  Unhandled Runtime Error
+                </h2>
+              </div>
+              <div className="flex gap-2">
+                <button 
+                  onClick={clearErrors}
+                  className="text-gray-400 hover:text-white px-2 py-1 text-sm border border-gray-600 rounded hover:border-gray-500 transition-colors"
+                >
+                  Clear
+                </button>
+                <button 
+                  onClick={() => setShowModal(false)}
+                  className="text-gray-400 hover:text-white text-2xl leading-none"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+
+            {/* 에러 내용 */}
+            <div className="flex-1 overflow-auto p-4">
+              {errors.map((error, index) => (
+                <div key={index} className="mb-6 last:mb-0">
+                  {/* 에러 메시지 */}
+                  <div className="mb-2">
+                    <span className="text-red-400 font-medium">Error: </span>
+                    <span className="text-white">{error.message}</span>
+                  </div>
+
+                  {/* 에러 스택 */}
+                  {error.stack && (
+                    <div className="bg-gray-800 rounded p-3 overflow-x-auto">
+                      <h3 className="text-sm font-medium text-gray-300 mb-2">Source</h3>
+                      <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+                        {error.stack}
+                      </pre>
+                    </div>
+                  )}
+
+                  {/* 구분선 */}
+                  {index < errors.length - 1 && (
+                    <hr className="border-gray-700 mt-4" />
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* 모달 푸터 */}
+            <div className="p-4 border-t border-gray-700 text-sm text-gray-400">
+              <p>This error overlay can be dismissed by clicking the X or pressing ESC.</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ErrorCounter;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,15 +2,54 @@
 const nextConfig = {
   reactStrictMode: false, // 에러 처리 문제 해결을 위해 일시적으로 비활성화
   transpilePackages: ['@vapor-ui/core', '@vapor-ui/icons'],
+  
   // 개발 환경에서의 에러 오버레이 설정
   devIndicators: {
     buildActivity: true,
     buildActivityPosition: 'bottom-right'
   },
+  
   // 개발 환경에서만 더 자세한 에러 로깅
   ...(process.env.NODE_ENV === 'development' && {
     experimental: {
       forceSwcTransforms: true
+    }
+  }),
+
+  // Webpack 설정으로 에러 오버레이 완전 비활성화
+  webpack: (config, { dev, isServer }) => {
+    if (dev && !isServer) {
+      // 에러 오버레이 모듈을 빈 모듈로 대체
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@next/react-dev-overlay/lib/client': false,
+        'next/dist/client/components/react-dev-overlay/hot-reloader-client': false,
+      };
+
+      // webpack-hot-middleware 설정
+      const originalEntry = config.entry;
+      config.entry = async () => {
+        const entries = await originalEntry();
+        
+        if (entries['main.js'] && !entries['main.js'].includes('./client/dev/noop.js')) {
+          // 에러 오버레이 관련 엔트리 제거
+          entries['main.js'] = entries['main.js'].filter(entry => 
+            !entry.includes('react-dev-overlay') && 
+            !entry.includes('hot-reloader')
+          );
+        }
+        
+        return entries;
+      };
+    }
+    
+    return config;
+  },
+
+  // 추가적인 개발 서버 설정
+  ...(process.env.NODE_ENV === 'development' && {
+    onDemandEntries: {
+      websocketPort: 3001,
     }
   })
 };

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -5,6 +5,7 @@ import { createThemeConfig } from '@vapor-ui/core';
 import '@vapor-ui/core/styles.css';
 import '../styles/globals.css';
 import Navbar from '../components/Navbar';
+import ErrorCounter from '../components/ErrorCounter'; // 새로 만들 컴포넌트
 
 // Create dark theme configuration
 const themeConfig = createThemeConfig({
@@ -27,6 +28,67 @@ function MyApp({ Component, pageProps }) {
 
   useEffect(() => {
     setMounted(true);
+
+    // 전역 에러 핸들링 - 기본 에러 오버레이 방지
+    const handleError = (event) => {
+      // 기본 Next.js 에러 오버레이 표시 방지
+      event.preventDefault();
+      event.stopPropagation();
+      
+      // 콘솔에만 에러 로그
+      console.error('Runtime Error:', event.error);
+      
+      // 커스텀 에러 카운터에 에러 전달
+      window.dispatchEvent(new CustomEvent('customError', {
+        detail: {
+          message: event.error?.message || 'Unknown error',
+          stack: event.error?.stack,
+          timestamp: Date.now()
+        }
+      }));
+      
+      return false;
+    };
+
+    const handleUnhandledRejection = (event) => {
+      // Promise rejection 에러도 방지
+      event.preventDefault();
+      console.error('Unhandled promise rejection:', event.reason);
+      
+      window.dispatchEvent(new CustomEvent('customError', {
+        detail: {
+          message: event.reason?.message || 'Promise rejection',
+          stack: event.reason?.stack,
+          timestamp: Date.now()
+        }
+      }));
+    };
+
+    // Next.js 개발 모드의 에러 오버레이 강제 제거
+    const removeErrorOverlay = () => {
+      const overlay = document.querySelector('nextjs-portal');
+      if (overlay) {
+        overlay.remove();
+      }
+      
+      // React Error Overlay도 제거
+      const reactOverlay = document.querySelector('#__next-build-watcher');
+      if (reactOverlay) {
+        reactOverlay.style.display = 'none';
+      }
+    };
+
+    // 주기적으로 에러 오버레이 체크 및 제거
+    const overlayChecker = setInterval(removeErrorOverlay, 100);
+
+    window.addEventListener('error', handleError, true);
+    window.addEventListener('unhandledrejection', handleUnhandledRejection, true);
+
+    return () => {
+      clearInterval(overlayChecker);
+      window.removeEventListener('error', handleError, true);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection, true);
+    };
   }, []);
 
   if (!mounted) {
@@ -39,6 +101,8 @@ function MyApp({ Component, pageProps }) {
     <ThemeProvider config={themeConfig}>
       {showNavbar && <Navbar />}
       <Component {...pageProps} />
+      {/* 커스텀 에러 카운터 컴포넌트 추가 */}
+      <ErrorCounter />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## 문제 상황

에러 발생할 때마다 헬퍼 텍스트가 뜨는데 불필요하게 에러 관련 모달창까지 뜸

## 원인

next에서 제공해주는 에러 오버레이를 활용하여 에러 모달창을 띄우는 것으로 확인됨

## 해결

에러 오버레이를 비활성화하여 불필요한 에러 모달창이 나타나지 않도록 수정함