### PR TITLE
FE: fix: 마크다운 중 제대로 적용 안 되는 것들 수정 (ul, ol, link)

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -380,8 +380,21 @@ const ChatInput = forwardRef(({
     let newCursorPos;
     let newSelectionStart;
     let newSelectionEnd;
-
-    if (markdown.includes('\n')) {
+  
+    if (markdown.includes('](') && markdown.startsWith('[')) {
+      if (selectedText) {
+        newText = message.substring(0, start) + `[${selectedText}](url)` + message.substring(end);
+        newSelectionStart = start + selectedText.length + 3;
+        newSelectionEnd = newSelectionStart + 3;
+        newCursorPos = newSelectionEnd;
+      } else {
+        newText = message.substring(0, start) + '[텍스트](url)' + message.substring(end);
+        newSelectionStart = start + 1;
+        newSelectionEnd = newSelectionStart + 3;
+        newCursorPos = newSelectionEnd;
+      }
+    }
+    else if (markdown.includes('\n')) {
       newText = message.substring(0, start) +
                 markdown.replace('\n\n', '\n' + selectedText + '\n') +
                 message.substring(end);
@@ -421,7 +434,7 @@ const ChatInput = forwardRef(({
       if (messageInputRef.current) {
         input.focus();
         input.setSelectionRange(newSelectionStart, newSelectionEnd);
-        if (selectedText) {
+        if (selectedText && !markdown.includes('](')) {
           input.setSelectionRange(newCursorPos, newCursorPos);
         }
       }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -508,6 +508,14 @@ body {
   margin: var(--vapor-space-050) 0;
 }
 
+.message-content .md-list.md-ul {
+  list-style-type: disc;
+}
+
+.message-content .md-list.md-ol {
+  list-style-type: decimal;
+}
+
 /* Code blocks */
 .message-content pre[class*="language-"] {
   margin: var(--vapor-space-100) 0;


### PR DESCRIPTION
## 문제 상황

ul, ol 마크다운이 실제로 적용되지 않음
link 클릭 시 2개가 생성됨

## 원인

`globals.css`에 ul, ol 관련 마크다운 누락
`ChatInput.js`에 링크 클릭하는 경우에 대한 처리 누락

## 해결

`globals.css`와 `ChatInput.js`에 누락된 부분을 추가하여 해결함

<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/d8f70222-6771-4b97-89df-d9ac4c82a7d2" />

<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/b83001fa-371f-4c47-8c34-d7186b569660" />
