### PR TITLE
FE: fix: 채팅 전송 시 본인 제외하고 안 읽은 사람수가 나타나도록 수정

### DIFF
--- a/frontend/components/chat/ReadStatus.js
+++ b/frontend/components/chat/ReadStatus.js
@@ -22,13 +22,13 @@ const ReadStatus = ({
   const unreadParticipants = useMemo(() => {
     if (messageType === 'system') return [];
     
-    return participants.filter(participant => 
-      !currentReaders.some(reader => 
-        reader.userId === participant._id || 
-        reader.userId === participant.id
-      )
-    );
-  }, [participants, currentReaders, messageType]);
+    return participants.filter(participant => {
+      const userId = participant._id || participant.id;
+      const hasNotRead = !currentReaders.some(reader => reader.userId === userId);
+      
+      return hasNotRead && (userId !== currentUserId);
+    });
+  }, [participants, currentReaders, messageType, currentUserId]);
 
   // 읽지 않은 참여자 수 계산
   const unreadCount = useMemo(() => {


### PR DESCRIPTION
## 문제 상황

채팅 메시지 전송 시 안 읽은 사람수가 나타나는데 본인을 포함하여 나타남

## 원인

안 읽은 사람수를 계산하는 로직에서 본인을 제외하지 않음

## 해결

안 읽은 사람수를 계산하는 로직에서 본인을 제외하도록 구현하여 해결함